### PR TITLE
Remove ADCIRC Modules dependency and add native fort.14 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+.DS_Store
+__pycache__/
+*.egg-info/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -3,13 +3,38 @@ Interpolate a digital elevation model (DEM) to an ADCIRC unstructured mesh.
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+Create the Conda environment and install the project:
 
-python -m pydem2grd
+```bash
+conda env create -f environment.yml
+conda activate pydem2grd
+```
+
+Or install it into an existing Python environment:
+
+```bash
+python -m pip install -e .
+```
+
+```bash
+python -m pydem2grd INPUT_FORT14 OUTPUT_FORT14 RASTER_LIST
+```
+
+Installing the project also provides the equivalent `pydem2grd` command.
+
+For example:
+
+```bash
+python -m pydem2grd example/mesh_x1002.grd interpolated.grd rasterlist.txt
+```
+
+Run `python -m pydem2grd --help` for interpolation method, multiplication
+factor, and minimum-depth options.
 
 The following is a list of nodal flag values that are accepted.
-* -1000/-1001: Automatic CAA method of Bilskie and Hagen (2012). This flag value will create the most topographically accurate surface.
-* -10XX: Flagged values less than -1001 will use a CAA * XX value. This is used for smoothing. For example, a flag value of -1002 will mutliple the default CAA value by 2 thereby increasing the control volume/stencil by 2. A flag value of -1002 is a good choice that balances topographic accuracy and smoothness of the topobathy required for a numerical simulation.
+
+* -1000/-1001: Automatic CA method of Bilskie and Hagen (2012). This flag value will create the most topographically accurate surface.
+* -10XX: Flagged values less than -1001 use a CA scale factor of XX. This is used for smoothing. For example, -1002 multiplies the default control-area radius by 2, increasing the interpolation stencil.
 * -2000: This flag is used for vertical/raised feature nodes. Elevation values larger than mean + 2*sigma are averaged so the crown of a feature is captured.
 
 ## Docker
@@ -20,42 +45,33 @@ https://hub.docker.com/r/mbilskie/pydem2grd/tags
 
 docker pull mbilskie/pydem2grd:1
 
-## Prerequisites
+## Dependencies
 
-What things you need to install the software and how to install them
+* [NumPy](https://numpy.org/)
+* [Shapely](https://shapely.readthedocs.io/en/stable/)
+* [Rasterio](https://rasterio.readthedocs.io/en/stable/)
 
-* [ADCIRC Modules](https://github.com/zcobell/ADCIRCModules)
-* [GDAL](https://pypi.org/project/GDAL/)
-* [shapely](https://shapely.readthedocs.io/en/stable/)
-* [rasterio](https://rasterio.readthedocs.io/en/stable/#)
+ADCIRC `fort.14`/`.grd` files are read and written natively. Boundary sections
+are retained when a mesh is written, while boundary nodes used by interpolation
+are derived from the element topology.
 
-### Installing
+```python
+from pydem2grd import Mesh
 
-A step by step series of examples that tell you how to get a development env running
-
-Say what the step will be
-
+mesh = Mesh.from_file("fort.14")
+mesh.write("fort-updated.14")
 ```
-Give the example
-```
-
-And repeat
-
-```
-until finished
-```
-
-End with an example of getting some data out of the system or using it for a little demo
 
 ## Running the tests
 
-Explain how to run the automated tests for this system
-
-### Break down into end to end tests
+```bash
+python -m unittest discover -s tests
+```
 
 ## Built With
 
-* [ADCIRC Modules](https://github.com/zcobell/ADCIRCModules) - The ADCIRC file I/O used
+* Native Python ADCIRC `fort.14` mesh I/O
+* Rasterio-based DEM access (no direct `osgeo.gdal` dependency)
 
 ## Contributing
 
@@ -94,7 +110,8 @@ This project is still under development.
 
 ## License
 
-This project is licensed under the *** License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the GNU General Public License v3.0; see
+[`LICENSE`](LICENSE) for details.
 
 ## Acknowledgments
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: pydem2grd
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.9
+  - numpy
+  - rasterio
+  - shapely
+  - pip
+  - pip:
+      - -e .

--- a/pydem2grd/__init__.py
+++ b/pydem2grd/__init__.py
@@ -1,0 +1,5 @@
+"""PyDEM2GRD public API."""
+
+from .mesh import Fort14Error, Mesh
+
+__all__ = ["Fort14Error", "Mesh"]

--- a/pydem2grd/__main__.py
+++ b/pydem2grd/__main__.py
@@ -1,6 +1,9 @@
 from pydem2grd import app
-#import cProfile
 
-if __name__=='__main__':
-    #cProfile.run('app.run()')
-    app.run()
+
+def main(argv=None):
+    app.run(argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/pydem2grd/app.py
+++ b/pydem2grd/app.py
@@ -1,46 +1,42 @@
-# File: app.py
-# Name: Matthew V. Bilskie
+"""Command-line application for PyDEM2GRD."""
 
-#----------------------------------------------------------
-# M O D U L E S                                   
-#----------------------------------------------------------
-#----------------------------------------------------------
-import pyadcircmodules
-from pydem2grd.src.interpolate import interpolate 
-from pydem2grd.src.interpolate import griddata
-#----------------------------------------------------------
+import argparse
 
-def run():
-    ''' 
-    inmeshfile = raw_input('Name of mesh file: ')
-    outmeshfile = raw_input('Name of output mesh file: ')
-    rlistfile = raw_input('Name of raster list file: ')
-    mfac = float(raw_input('Multiplication factor (e.g. -1): '))
-    '''
+from pydem2grd.mesh import Mesh
+from pydem2grd.src.interpolate import interpolate
 
-    inmeshfile = "flaggedx3_utm15.grd"     
-    outmeshfile = "interpolatedx3_z.grd"
-    mfac = float(-1.0)
-    #minbath = 0.25
-    #minbath = -0.25
-    minbath = 0.00
-    rlistfile = 'rasterlist.txt'
 
-    mymesh = pyadcircmodules.Mesh(inmeshfile)
-    print('Reading mesh...')
-    ierr = mymesh.read()
-    if ierr == 0:
-        exit(ierr)
-    print('Building element table...')
-    #mymesh.buildElementTable()
-    mymesh.topology().elementTable().build()
-   
-    print('Interpolating...')
-    #imethod = 'griddata'
-    imethod = 'CA'
-    intmesh = interpolate(mymesh,rlistfile,minbath,mfac,imethod)
+def _arguments(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Interpolate DEM elevations onto an ADCIRC fort.14 mesh."
+    )
+    parser.add_argument("input_mesh", help="input fort.14/ADCIRC grid file")
+    parser.add_argument("output_mesh", help="output fort.14/ADCIRC grid file")
+    parser.add_argument("raster_list", help="text file containing one raster path per line")
+    parser.add_argument("--multiplication-factor", "-m", type=float, default=-1.0)
+    parser.add_argument("--minimum-bathymetric-depth", type=float, default=0.0)
+    parser.add_argument("--method", choices=("CA", "griddata"), default="CA")
+    return parser.parse_args(argv)
+
+
+def run(argv=None):
+    args = _arguments(argv)
+    mesh = Mesh(args.input_mesh)
+    print("Reading mesh...")
+    mesh.read()
+    print("Building element table...")
+    mesh.buildElementTable()
+
+    print("Interpolating...")
+    interpolated_mesh = interpolate(
+        mesh,
+        args.raster_list,
+        args.minimum_bathymetric_depth,
+        args.multiplication_factor,
+        args.method,
+    )
     
-    print('Saving mesh file...')
-    intmesh.write(outmeshfile)
+    print("Saving mesh file...")
+    interpolated_mesh.write(args.output_mesh)
 
-    print('Finished! :)')
+    print("Finished.")

--- a/pydem2grd/mesh.py
+++ b/pydem2grd/mesh.py
@@ -1,0 +1,279 @@
+"""Native ADCIRC ``fort.14`` mesh support.
+
+The small compatibility API in this module is intentionally shaped like the
+mesh operations that PyDEM2GRD uses. This keeps the interpolation code focused
+on interpolation while making mesh I/O a local, testable part of the project.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+from math import hypot
+from pathlib import Path
+
+
+class Fort14Error(ValueError):
+    """Raised when an ADCIRC mesh is malformed or unsupported."""
+
+
+@dataclass
+class Node:
+    _id: int
+    _x: float
+    _y: float
+    _z: float
+
+    def id(self):
+        return self._id
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def z(self):
+        return self._z
+
+
+@dataclass
+class Element:
+    _id: int
+    node_ids: tuple
+
+    def id(self):
+        return self._id
+
+
+class _ElementTableBuilder:
+    def __init__(self, mesh):
+        self._mesh = mesh
+
+    def build(self):
+        self._mesh.buildElementTable()
+
+
+class _Topology:
+    def __init__(self, mesh):
+        self._mesh = mesh
+
+    def elementTable(self):
+        return _ElementTableBuilder(self._mesh)
+
+
+class Mesh:
+    """An in-memory ADCIRC mesh with native ``fort.14`` read/write support."""
+
+    def __init__(self, filename=None):
+        self.filename = Path(filename) if filename is not None else None
+        self.title = ""
+        self._nodes = []
+        self._elements = []
+        self._node_indices = {}
+        self._element_indices = {}
+        self._element_table = None
+        self._boundary_lines = []
+        self.size = []
+
+    @classmethod
+    def from_file(cls, filename):
+        mesh = cls(filename)
+        mesh.read()
+        return mesh
+
+    def read(self, filename=None):
+        if filename is not None:
+            self.filename = Path(filename)
+        if self.filename is None:
+            raise ValueError("A fort.14 filename is required")
+
+        try:
+            with self.filename.open("r", encoding="utf-8") as stream:
+                lines = stream.readlines()
+        except OSError as exc:
+            raise Fort14Error("Could not read {}: {}".format(self.filename, exc)) from exc
+
+        if len(lines) < 2:
+            raise Fort14Error("{} must contain a title and size header".format(self.filename))
+
+        self.title = lines[0].rstrip("\r\n")
+        counts = lines[1].split()
+        if len(counts) < 2:
+            raise Fort14Error("Line 2 must contain element and node counts")
+        try:
+            element_count, node_count = int(counts[0]), int(counts[1])
+        except ValueError as exc:
+            raise Fort14Error("Line 2 contains invalid element or node counts") from exc
+        if element_count < 0 or node_count < 0:
+            raise Fort14Error("Element and node counts cannot be negative")
+
+        cursor = 2
+        nodes = []
+        for _ in range(node_count):
+            line_number = cursor + 1
+            if cursor >= len(lines):
+                raise Fort14Error("Unexpected end of file while reading nodes")
+            fields = lines[cursor].split()
+            cursor += 1
+            if len(fields) < 4:
+                raise Fort14Error("Line {} is not a valid node record".format(line_number))
+            try:
+                nodes.append(Node(int(fields[0]), float(fields[1]), float(fields[2]), float(fields[3])))
+            except ValueError as exc:
+                raise Fort14Error("Line {} contains an invalid node record".format(line_number)) from exc
+
+        node_ids = {node.id() for node in nodes}
+        if len(node_ids) != len(nodes):
+            raise Fort14Error("Node IDs must be unique")
+
+        elements = []
+        for _ in range(element_count):
+            line_number = cursor + 1
+            if cursor >= len(lines):
+                raise Fort14Error("Unexpected end of file while reading elements")
+            fields = lines[cursor].split()
+            cursor += 1
+            try:
+                element_id = int(fields[0])
+                vertex_count = int(fields[1])
+                element_nodes = tuple(int(value) for value in fields[2:])
+            except (IndexError, ValueError) as exc:
+                raise Fort14Error("Line {} is not a valid element record".format(line_number)) from exc
+            if vertex_count < 3 or len(element_nodes) != vertex_count:
+                raise Fort14Error(
+                    "Line {} declares {} element nodes but contains {}".format(
+                        line_number, vertex_count, len(element_nodes)
+                    )
+                )
+            missing = set(element_nodes) - node_ids
+            if missing:
+                raise Fort14Error(
+                    "Line {} references unknown node ID(s): {}".format(
+                        line_number, ", ".join(str(value) for value in sorted(missing))
+                    )
+                )
+            elements.append(Element(element_id, element_nodes))
+
+        if len({element.id() for element in elements}) != len(elements):
+            raise Fort14Error("Element IDs must be unique")
+
+        self._nodes = nodes
+        self._elements = elements
+        self._node_indices = {node.id(): index for index, node in enumerate(nodes)}
+        self._element_indices = {element.id(): index for index, element in enumerate(elements)}
+        self._boundary_lines = [line.rstrip("\r\n") for line in lines[cursor:]]
+        self._element_table = None
+        self.size = []
+        return True
+
+    def write(self, filename=None):
+        destination = Path(filename) if filename is not None else self.filename
+        if destination is None:
+            raise ValueError("A fort.14 output filename is required")
+
+        with destination.open("w", encoding="utf-8", newline="\n") as stream:
+            stream.write("{}\n".format(self.title))
+            stream.write("{} {}\n".format(self.numElements(), self.numNodes()))
+            for node in self._nodes:
+                stream.write(
+                    "{} {:.16g} {:.16g} {:.16g}\n".format(
+                        node.id(), node.x(), node.y(), node.z()
+                    )
+                )
+            for element in self._elements:
+                stream.write(
+                    "{} {} {}\n".format(
+                        element.id(), len(element.node_ids), " ".join(map(str, element.node_ids))
+                    )
+                )
+            boundary_lines = self._boundary_lines or [
+                "0 = Number of open boundaries",
+                "0 = Total number of open boundary nodes",
+                "0 = Number of land boundaries",
+                "0 = Total number of land boundary nodes",
+            ]
+            for line in boundary_lines:
+                stream.write("{}\n".format(line))
+
+        self.filename = destination
+
+    def numNodes(self):
+        return len(self._nodes)
+
+    def numElements(self):
+        return len(self._elements)
+
+    def node(self, index):
+        return self._nodes[index]
+
+    def nodeIndexById(self, node_id):
+        try:
+            return self._node_indices[int(node_id)]
+        except KeyError as exc:
+            raise KeyError("Unknown node ID {}".format(node_id)) from exc
+
+    def elementIndexById(self, element_id):
+        try:
+            return self._element_indices[int(element_id)]
+        except KeyError as exc:
+            raise KeyError("Unknown element ID {}".format(element_id)) from exc
+
+    def connectivity(self):
+        return [list(element.node_ids) for element in self._elements]
+
+    def buildElementTable(self):
+        table = [[] for _ in self._nodes]
+        for element in self._elements:
+            for node_id in element.node_ids:
+                table[self.nodeIndexById(node_id)].append(element)
+        self._element_table = table
+
+    def topology(self):
+        return _Topology(self)
+
+    def elementTable(self, node, index):
+        if self._element_table is None:
+            self.buildElementTable()
+        return self._element_table[self.nodeIndexById(node.id())][index]
+
+    def numElementsAroundNode(self, node_index):
+        if self._element_table is None:
+            self.buildElementTable()
+        return len(self._element_table[node_index])
+
+    def boundaryNodes(self):
+        edge_counts = Counter()
+        for element in self._elements:
+            node_ids = element.node_ids
+            for index, node_id in enumerate(node_ids):
+                edge_counts[tuple(sorted((node_id, node_ids[(index + 1) % len(node_ids)])))] += 1
+        boundary_ids = {
+            node_id
+            for edge, count in edge_counts.items()
+            if count == 1
+            for node_id in edge
+        }
+        return [node for node in self._nodes if node.id() in boundary_ids]
+
+    def computeMeshSize(self):
+        lengths = [[] for _ in self._nodes]
+        seen_edges = set()
+        for element in self._elements:
+            node_ids = element.node_ids
+            for index, first_id in enumerate(node_ids):
+                second_id = node_ids[(index + 1) % len(node_ids)]
+                edge = tuple(sorted((first_id, second_id)))
+                if edge in seen_edges:
+                    continue
+                seen_edges.add(edge)
+                first = self.node(self.nodeIndexById(first_id))
+                second = self.node(self.nodeIndexById(second_id))
+                length = hypot(second.x() - first.x(), second.y() - first.y())
+                lengths[self.nodeIndexById(first_id)].append(length)
+                lengths[self.nodeIndexById(second_id)].append(length)
+        return [sum(values) / len(values) if values else 0.0 for values in lengths]
+
+    def setZ(self, values):
+        if len(values) != self.numNodes():
+            raise ValueError("Expected {} elevations, got {}".format(self.numNodes(), len(values)))
+        for node, value in zip(self._nodes, values):
+            node._z = float(value)

--- a/pydem2grd/src/interpolate.py
+++ b/pydem2grd/src/interpolate.py
@@ -1,485 +1,310 @@
-# File: interpolate.py
-# Name: Matthew V. Bilskie
+"""DEM-to-mesh interpolation routines."""
 
-#----------------------------------------------------------
-# M O D U L E S                                   
-#----------------------------------------------------------
-#----------------------------------------------------------
-import pyadcircmodules
-import rasterio
-import sys
-import csv
-from osgeo import gdal
-import numpy as np
-import operator
 import math
-from shapely.geometry import box    
-from shapely.geometry import Point 
-from shapely.geometry import Polygon 
-from shapely.geometry import mapping
-from .raster import get_rastersize
-from .raster import get_numrowcol
-from .raster import get_boundingbox
-from .raster import pixel2coord
-from .raster import coord2pixel
-from rasterio.mask import mask
+import operator
 from functools import reduce
-#----------------------------------------------------------
+from pathlib import Path
 
-#----------------------------------------------------------
-# F U N C T I O N    G R I D D A T A
-#
-#----------------------------------------------------------
-def griddata(mesh,meshconn,xc,yc,boundaryNodes,raster,mfac,values,numvaluesgathered):
-        
+import numpy as np
+import rasterio
+from rasterio.mask import mask
+from shapely.geometry import Point, Polygon, box, mapping
+
+from .raster import (
+    coord2pixel,
+    get_boundingbox,
+    get_numrowcol,
+    get_rastersize,
+    open_raster,
+    read_band_as_array,
+)
+
+
+def griddata(
+    mesh,
+    meshconn,
+    xc,
+    yc,
+    boundary_nodes,
+    raster,
+    multiplication_factor,
+    values,
+    num_values_gathered,
+):
+    """Gather raster cells within a centroid-based control polygon."""
     mesh.size = mesh.computeMeshSize()
-    
-    data = gdal.Open(raster, gdal.GA_ReadOnly)
-    bbox = get_boundingbox(data)
-    bboxPoly = box(bbox[0],bbox[1],bbox[2],bbox[3])
-    rastersize = get_rastersize(data)
-    
-    # Create a polygon of the Voronoi Diagram about each node
-    for i in range(mesh.numNodes()):
 
-        bufr = 1.25 * mesh.size[i] * rastersize
-        if ( not bboxPoly.buffer(bufr).contains(Point(mesh.node(i).x(),mesh.node(i).y())) or
-                (mesh.node(i).z() > -999.0) ):
+    with open_raster(raster) as data:
+        bbox = get_boundingbox(data)
+        bbox_polygon = box(*bbox)
+        raster_size = get_rastersize(data)
+
+    for index in range(mesh.numNodes()):
+        node = mesh.node(index)
+        buffer_radius = 1.25 * mesh.size[index] * raster_size
+        if not bbox_polygon.buffer(buffer_radius).contains(Point(node.x(), node.y())):
+            continue
+        if node.z() > -999.0:
             continue
 
-        # Get the number of elements that surround node i
-        numElem = mesh.numElementsAroundNode(i)
+        num_elements = mesh.numElementsAroundNode(index)
+        point_list = []
+        for surrounding_index in range(num_elements):
+            element = mesh.elementTable(node, surrounding_index)
+            element_index = mesh.elementIndexById(element.id())
+            point_list.append((xc[element_index], yc[element_index]))
 
-        # Use the elements that are connected to node i
-        # to construct a Voroni Polygon
-        pointList = []
-        for j in range(numElem):
-            # Build a polygon of centroids (vornoi diagram)
-
-            pointList.append((xc[mesh.elementTable(mesh.node(i),j).id()-1],
-                yc[mesh.elementTable(mesh.node(i),j).id()-1]))
-            
-        # Check if the mesh node is a boundary node.
-        # If so, then the Voroni Diagram should be constructed with
-        # the centroids as well as the mid-point along each boundary
-        # line segment and the node coordinates itself
-        if (mesh.node(i).id() in boundaryNodes):
-            #print 'Boundary node found...'
-       
-            # If a boundary node is outside the raster, then skip it
-            if ( not bboxPoly.contains(Point(mesh.node(i).x(),mesh.node(i).y())) ):
+        if node.id() in boundary_nodes:
+            if not bbox_polygon.contains(Point(node.x(), node.y())):
                 continue
-            
-            # Add current mesh node coordinates to polygon
-            pointList.append((mesh.node(i).x(),mesh.node(i).y()))
+            point_list.append((node.x(), node.y()))
 
-            if numElem == 1:
-                #print mesh.elementTable(mesh.node(i),0).id()
-                #print meshconn[mesh.elementTable(mesh.node(i),0).id()-1]
-                #n1 = meshconn[mesh.elementTable(mesh.node(i),0).id()-1][0]
-                #n2 = meshconn[mesh.elementTable(mesh.node(i),0).id()-1][1]
-                #n3 = meshconn[mesh.elementTable(mesh.node(i),0).id()-1][2]
-                for k in range(3):
-                    if meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k] == mesh.node(i).id():
+            if num_elements == 1:
+                element = mesh.elementTable(node, 0)
+                element_index = mesh.elementIndexById(element.id())
+                for neighbor_id in meshconn[element_index]:
+                    if neighbor_id == node.id():
                         continue
+                    neighbor = mesh.node(mesh.nodeIndexById(neighbor_id))
+                    point_list.append(
+                        (
+                            0.5 * (node.x() + neighbor.x()),
+                            0.5 * (node.y() + neighbor.y()),
+                        )
+                    )
 
-                    neigh = mesh.nodeIndexById(meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k])
+        if len(point_list) < 3:
+            continue
 
-                    xmid = 0.5 * (mesh.node(i).x() + mesh.node(neigh).x())
-                    ymid = 0.5 * (mesh.node(i).y() + mesh.node(neigh).y())
+        center = tuple(
+            map(
+                operator.truediv,
+                reduce(lambda first, second: list(map(operator.add, first, second)), point_list),
+                [len(point_list)] * 2,
+            )
+        )
+        point_list = sorted(
+            point_list,
+            key=lambda coord: (
+                -135
+                - math.degrees(
+                    math.atan2(*tuple(map(operator.sub, coord, center))[::-1])
+                )
+            )
+            % 360,
+        )
+        voronoi_polygon = Polygon(point_list)
+        if not voronoi_polygon.is_valid or voronoi_polygon.area == 0:
+            continue
 
-                    pointList.append((xmid,ymid))
-
-            '''
-            # Stil working on this ...
-
-                # Find the other line segments that
-                # Search the other nodes of the connected elements to find the 
-                # other two boundary nodes
-                for j in range(numElem):
-
-                    neighEl = mesh.elementTable(mesh.node(i),j).id() # This is an element IDs connected to node i
-                    #print neighEl
-                    print '' 
-
-                    # Find if any of the nodes that touch the surrounding elements are bondary nodes
-                    for k in range(3):
-                        if meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k] == mesh.node(i).id():
-                            continue
-                        #print meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k]
-                        
-                        if meshconn[neighEl-1][k] == mesh.node(i).id():
-                            continue
-                        if (meshconn[neighEl-1][k] in boundaryNodes):
-                            print meshconn[neighEl-1][k]
-
-                quit()
-
-                    #print meshconn[j] # This is the nodes that make up the element
-                    for k in range(3): # 3 b/c 3 nodes make up an element
-                        
-                        # Skip the current nodes as its already been added to pointList
-                        #if meshconn[j][k] == mesh.node(i).id():
-                        if meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k] == mesh.node(i).id():
-                            continue
-
-                        if (meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k] in boundaryNodes):
-                            print 'boundary node'    
-                            neigh = mesh.nodeIndexById(meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k])
-                            xmid = 0.5 * (mesh.node(i).x() + mesh.node(neigh).x())
-                            ymid = 0.5 * (mesh.node(i).y() + mesh.node(neigh).y())
-                            
-                            pointList.append((xmid,ymid))
-
-                        #####
-                        # If one of the connected mesh nodes is on the boundary,
-                        # then find the mid-point to the current mesh node
-                        # and add that to pointList
-                        #if (meshconn[j][k] in boundaryNodes):
-                        if (meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k] in boundaryNodes):
-                            print meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k]
-                            # Find mid-point and add to pointList
-                            neigh = mesh.nodeIndexById(meshconn[mesh.elementTable(mesh.node(i),0).id()-1][k])
-                            
-                            xmid = 0.5 * (mesh.node(i).x() + mesh.node(neigh).x())
-                            ymid = 0.5 * (mesh.node(i).y() + mesh.node(neigh).y())
-                            #xmid = 0.5 * (mesh.node(i).x() + mesh.node(mesh.nodeIndexById(meshconn[j][k])).x())
-                            #ymid = 0.5 * (mesh.node(i).y() + mesh.node(mesh.nodeIndexById(meshconn[j][k])).y())
-                            
-                            pointList.append((xmid,ymid))
-                        ####
-        '''
-
-        # Sort the points in a clockwise fashion
-        # https://stackoverflow.com/questions/51074984/sorting-according-to-clockwise-point-coordinates
-        center = tuple(map(operator.truediv, reduce(lambda x, y: list(map(operator.add, x, y)), pointList), [len(pointList)] * 2))
-        pointList = (sorted(pointList, key=lambda coord: (-135 - math.degrees(math.atan2(*tuple(map(operator.sub, coord, center))[::-1]))) % 360))
-        '''   
-        if mesh.node(i).id() == 9775:
-            rows = zip(pointList)
-            with open('VoroniDiagram.csv', 'wb') as myfile:
-                    wr = csv.writer(myfile,sys.stdout, delimiter="\t", quoting = csv.QUOTE_NONE)
-                    #wr.writerow(pointList)
-                    for row in rows:
-                        wr.writerow(row)
-            quit()
-        ''' 
-        
-        # Generate a polygon of the pointList
-        vor = Polygon(pointList)
-
-        # Mapping converts the vor polygon to a GeoJSON-like mapping of a geometric object.
-        # This is needed for the mask operation below
-        geoms = [mapping(vor)]
-        # https://rasterio.readthedocs.io/en/stable/api/rasterio.mask.html
-        # https://rasterio.readthedocs.io/en/stable/topics/masking-by-shapefile.html
-        rbbox = []
-        with rasterio.open(raster) as src:
-            # Build the bounding box of the raster to check if it intersects
-            # the stencil for interpolation
-            rbbox.append((src.bounds[0],src.bounds[1])) # bottom left
-            rbbox.append((src.bounds[0],src.bounds[3])) # top left
-            rbbox.append((src.bounds[2],src.bounds[3])) # top right
-            rbbox.append((src.bounds[2],src.bounds[1])) # bottom right
-            rbbox = Polygon(rbbox)
-            # p1.intersects(p2) is true if p1 intersects p2
-            if not (rbbox.intersects(vor)):
+        with rasterio.open(raster) as source:
+            raster_polygon = box(*source.bounds)
+            if not raster_polygon.intersects(voronoi_polygon):
                 continue
-            ndv = src.nodata
-            out_image, out_transform = mask(src,geoms,crop=True)
-        # For Debugging
-        # Writes out the masked raster
-        # https://rasterio.readthedocs.io/en/stable/topics/masking-by-shapefile.html
-        '''
-        out_meta = src.meta
-        out_meta.update({"driver": "GTiff",
-            "height": out_image.shape[1],
-            "width" : out_image.shape[2],
-            "transform": out_transform})
-        with rasterio.open("01_test.tif", "w", **out_meta) as dest:
-            dest.write(out_image)
-        quit()
-        '''
+            out_image, _ = mask(
+                source,
+                [mapping(voronoi_polygon)],
+                crop=True,
+                filled=False,
+            )
 
-        # Convert the subset matrix to an array
-        subset = np.asarray(out_image)
-        # Remove no data values to mitigate any overflow issues
-        subset = subset[subset > ndv]
-        subset = subset * mfac
-        numvaluesgathered[i] = numvaluesgathered[i] + subset.size
-        values[i] = values[i] + np.sum(subset)
+        subset = out_image.compressed() * multiplication_factor
+        subset = subset[np.isfinite(subset)]
+        if subset.size == 0:
+            continue
+        num_values_gathered[index] += subset.size
+        values[index] += np.sum(subset)
 
-    return(values,numvaluesgathered)
-   
-#----------------------------------------------------------
-# F U N C T I O N    M E S H C O N N E C T I V I T Y
-#----------------------------------------------------------
-#
-# Finds the connectivitiy of the mesh includes elemental
-# connectivity and the boundary nodes
-# result = function(mesh)
-#----------------------------------------------------------
+    return values, num_values_gathered
+
+
 def meshconnectivity(mesh):
-
+    """Return element connectivity, centroids, and topological boundary IDs."""
     meshconn = mesh.connectivity()
-
-    # Find the centroid of the elements
     xc = np.zeros(mesh.numElements())
     yc = np.zeros(mesh.numElements())
-    for i in range(mesh.numElements()-1):
 
-        x1 = mesh.node(mesh.nodeIndexById(meshconn[i][0])).x()
-        x2 = mesh.node(mesh.nodeIndexById(meshconn[i][1])).x()
-        x3 = mesh.node(mesh.nodeIndexById(meshconn[i][2])).x()
-        
-        y1 = mesh.node(mesh.nodeIndexById(meshconn[i][0])).y()
-        y2 = mesh.node(mesh.nodeIndexById(meshconn[i][1])).y()
-        y3 = mesh.node(mesh.nodeIndexById(meshconn[i][2])).y()
+    for index, node_ids in enumerate(meshconn):
+        if len(node_ids) != 3:
+            raise ValueError("griddata interpolation requires triangular elements")
+        nodes = [mesh.node(mesh.nodeIndexById(node_id)) for node_id in node_ids]
+        xc[index] = sum(node.x() for node in nodes) / 3.0
+        yc[index] = sum(node.y() for node in nodes) / 3.0
 
-        # Calculate the centroid (xc,yc)
-        xc[i] = (x1 + x2 + x3) / 3
-        yc[i] = (y1 + y2 + y3) / 3
+    boundary_nodes = [int(node.id()) for node in mesh.boundaryNodes()]
+    return meshconn, xc, yc, boundary_nodes
 
-    # Grab the mesh nodes along the boundary
-    boundaryNodesPntr = mesh.boundaryNodes()
-    boundaryNodes = []
-    for i in range(len(boundaryNodesPntr)):
-        boundaryNodes.append(int(boundaryNodesPntr[i].id()))
 
-    return meshconn, xc, yc, boundaryNodes
+def gathervalues(
+    mesh,
+    raster,
+    cell_radii,
+    control_areas,
+    multiplication_factor,
+    values,
+    num_values_gathered,
+):
+    """Gather raster values from square control areas around mesh nodes."""
+    with open_raster(raster) as data:
+        num_cols, num_rows = get_numrowcol(data)
+        raster_values = read_band_as_array(data, masked=True).astype(float)
+        raster_values *= multiplication_factor
+        raster_size = get_rastersize(data)
+        bbox = get_boundingbox(data)
 
-#----------------------------------------------------------
-# F U N C T I O N    G A T H E R V A L U E S      
-#----------------------------------------------------------
-#
-# Sums up the raster pixel values within stencil
-# result = function(mesh, raster, values, numvaluesgathered)
-#----------------------------------------------------------
-def gathervalues(mesh,raster,N,CA,mfac,values,numvaluesgathered):
+        for index in range(mesh.numNodes()):
+            node = mesh.node(index)
+            if node.z() > -999.0:
+                continue
 
-    data = gdal.Open(raster, gdal.GA_ReadOnly)
-    # Find the total number of rows and columns in the raster
-    numcols, numrows = get_numrowcol(data)
-    # Go ahead and load up raster values
-    band = data.GetRasterBand(1)
-    band.SetNoDataValue(-9999)
-    vals = band.ReadAsArray()
-    vals = vals * mfac
+            radius = int(cell_radii[index])
+            coordinate_radius = (radius + 1) * raster_size
+            if (
+                node.x() < bbox[0] - coordinate_radius
+                or node.x() > bbox[2] + coordinate_radius
+                or node.y() < bbox[1] - coordinate_radius
+                or node.y() > bbox[3] + coordinate_radius
+            ):
+                continue
 
-    rastersize = get_rastersize(data)
-    
-    bbox = get_boundingbox(data)
-    bboxPoly = box(bbox[0],bbox[1],bbox[2],bbox[3])
-    
-    for i in range(mesh.numNodes()):
+            if num_values_gathered[index] == control_areas[index]:
+                continue
 
-        # Check if node is inside the raster bbox + some buffer
-        # Only interpolate on flagged nodes
-        if mesh.node(i).z() > -999.0:
-            continue
+            col, row = coord2pixel(node.x(), node.y(), data)
+            if col < 0 or row < 0:
+                continue
 
-        # Check to make sure mesh node is inside the raster
-        # plus some buffer = rastersize * N 
-        if ( mesh.node(i).x() < bbox[0] - (N[i]+1*rastersize) ) or \
-                ( mesh.node(i).x() > bbox[2] + (N[i]+1*rastersize) ) or \
-                ( mesh.node(i).y() < bbox[1] - (N[i]+1*rastersize) ) or \
-                ( mesh.node(i).y() > bbox[3] + (N[i]+1*rastersize) ):
-            continue
+            left = max(col - radius, 0)
+            right = min(col + radius + 1, num_cols)
+            top = max(row - radius, 0)
+            bottom = min(row + radius + 1, num_rows)
+            if left >= right or top >= bottom:
+                continue
 
-        # Check if the total number of cells have already been acquired
-        if (numvaluesgathered[i] == CA[i]):
-            continue
-
-        # Check if part of the stencil is inside the raster
-        col, row  = coord2pixel(mesh.node(i).x(),mesh.node(i).y(),data)
-        
-        #print "# Rows, # Columns ",numrows,numcols
-        #print "Row, Column ",row, col
-
-        # Get the stencil size in number of rows/cols around the current row/col
-        # Left to right and top to bottom nomenclature
-        left = int(col - N[i])
-        bottom = int(row + N[i])
-        right = int(col + N[i])
-        top = int(row - N[i])
-        
-        # Check for negative col/row values in the stencil
-        #if ( (left < 0) and (bottom < 0) ):
-            #continue
-        if top < 0:
-            top = 0
-        if bottom < 0:
-            bottom = 0
-        if left < 0:
-            left = 0
-        if right < 0:
-            right = 0
-
-        # Find the x,y coordinates of the stencil and build polygon
-        xmin,ymin = pixel2coord(left,bottom,data)
-        xmax,ymax = pixel2coord(right,top,data)
-        stencilPoly = box(xmin,ymin,xmax,ymax)
-        
-        if (not stencilPoly.touches(bboxPoly)):
-            # Find which stencil cells are contained in the raster
-            subset = vals[top:bottom,left:right]
-            
-            # Convert the subset matrix to an array
-            subset = np.asarray(subset)
-
-            # Remove no data values to mitigate any overflow issues
-            subset = subset[subset >= -999]
-            subset = subset[subset <= 999]
-            
-            # Check to make sure there are valid elevations in the stencil
+            subset = raster_values[top:bottom, left:right].compressed()
+            subset = subset[np.isfinite(subset)]
+            subset = subset[(subset >= -999) & (subset <= 999)]
             if subset.size == 0:
                 continue
 
-            # Check for vertical/raised feature nodes
-            if mesh.node(i).z() == -2000:
-
-                # Find the mean and standard deviation
+            if node.z() == -2000:
                 mean = np.average(subset)
-                std = np.std(subset)
-
-                # If the node is in the bounds of more than 1 raster,
-                # then keep the highest (minimum for ADCIRC) value.
-                if ( (mean - 2*std) < np.min(subset) ):
-
-                    values[i] = np.min(subset)
-                    numvaluesgathered[i] = -2000
-
+                standard_deviation = np.std(subset)
+                threshold = mean - 2 * standard_deviation
+                if threshold < np.min(subset):
+                    values[index] = np.min(subset)
                 else:
-
-                    subset = subset[subset <= (mean - 2*std)]
-                    values[i] = np.mean(subset)
-                    numvaluesgathered[i] = -2000
-                
-                print(('Mesh Node ',mesh.node(i).id(),' is a raised feature node w/ elevation: ',values[i]))
-                
-            # Not flagged as a vertical/raised feature node
+                    raised_values = subset[subset <= threshold]
+                    values[index] = (
+                        np.mean(raised_values) if raised_values.size else np.min(subset)
+                    )
+                num_values_gathered[index] = -2000
             else:
+                values[index] += np.sum(subset)
+                num_values_gathered[index] += subset.size
 
-                # Sum values in the stencil
-                values[i] = values[i] + np.sum(subset)
-                numvaluesgathered[i] = numvaluesgathered[i] + np.size(subset)
-        
-        else:
-            
-            print((i+1,'Does not overlap'))
-            continue
-    
-    return(values,numvaluesgathered)
-#----------------------------------------------------------
-    
+    return values, num_values_gathered
 
-#----------------------------------------------------------
-# F U N C T I O N    I N T E R P O L A T E        
-#----------------------------------------------------------
-#
-# Cycle through a list of rasters and interpolate
-# DEM values to the mesh.
-# result = function(mesh, rasterlist)
-#----------------------------------------------------------
-def interpolate(mesh,rasterlist,minBathyDepth,mfac,imethod):
-    # Grab list of raster files
-    f = open(rasterlist,'r')
-    files = f.readlines()
-    val = np.zeros(mesh.numNodes())
-    numval = np.zeros(mesh.numNodes())
-   
-    # Compute the local mesh size (meters)
+
+def _raster_paths(raster_list):
+    raster_list = Path(raster_list)
+    base_directory = raster_list.resolve().parent
+    paths = []
+    for line in raster_list.read_text(encoding="utf-8").splitlines():
+        value = line.strip()
+        if value and not value.startswith("#"):
+            path = Path(value.split()[0])
+            paths.append(str(path if path.is_absolute() else base_directory / path))
+    return paths
+
+
+def interpolate(mesh, raster_list, minimum_bathymetric_depth, multiplication_factor, method):
+    """Interpolate every flagged mesh node from the listed DEM rasters."""
+    if method not in ("CA", "griddata"):
+        raise ValueError("Unknown interpolation method: {}".format(method))
+
+    raster_paths = _raster_paths(raster_list)
+    if not raster_paths:
+        raise ValueError("Raster list does not contain any raster paths")
+
+    values = np.zeros(mesh.numNodes())
+    num_values = np.zeros(mesh.numNodes())
     mesh.size = mesh.computeMeshSize()
 
-    if imethod == "griddata":
-        print('Computing mesh connectivity...')
-        meshconn, xc, yc, boundaryNodes = meshconnectivity(mesh)
-        print('done!')
+    if method == "griddata":
+        print("Computing mesh connectivity...")
+        meshconn, xc, yc, boundary_nodes = meshconnectivity(mesh)
+        print("done!")
 
-    rastersize = 0
-    for f in files:
-        print(f)
-        # Cycle through each raster
-        if imethod == "CA":
-            # Check to see if raster size changed
-            data = gdal.Open(f.split()[0], gdal.GA_ReadOnly)
-            newrastersize = get_rastersize(data)
-            if (abs(rastersize-newrastersize) > 0.10): # Raster size changed > 10 cm
-                # Re-calculate N and CA based on the updated raster size
-                print(('Raster size changed from ',rastersize,' to ',newrastersize,'. Re-calculating N & CA.'))
-                rastersize = newrastersize
-                numCells = compute_numcells(mesh,rastersize)
-                numCells = np.asarray(numCells)
-                N = numCells[0,:]
-                CA = numCells[1,:]
+    raster_size = None
+    cell_radii = None
+    control_areas = None
+    for raster in raster_paths:
+        print(raster)
+        if method == "CA":
+            with open_raster(raster) as data:
+                new_raster_size = get_rastersize(data)
+            if raster_size is None or abs(raster_size - new_raster_size) > 0.10:
+                print(
+                    "Raster size changed from {} to {}. Re-calculating control areas.".format(
+                        raster_size or 0.0, new_raster_size
+                    )
+                )
+                raster_size = new_raster_size
+                cell_radii, control_areas = compute_numcells(mesh, raster_size)
 
-            a,b = gathervalues(mesh,f.split()[0],N,CA,mfac,val,numval)
-        elif imethod == "griddata":
-            a,b = griddata(mesh,meshconn,xc,yc,boundaryNodes,f.split()[0],mfac,val,numval)
-        val = a
-        numval = b
-
-    interpvalues = np.zeros(mesh.numNodes())
-    for i in range(mesh.numNodes()):
-
-        if (numval[i] == 0):
-
-            interpvalues[i] = mesh.node(i).z()
-
-        elif (numval[i] == -2000):
-
-            interpvalues[i] = val[i]
-
-        elif (numval[i] != 0):
-
-            interpvalues[i] = val[i] / numval[i]
-
-        # Check for minimum bathy depth
-        #if interpvalues[i] >= 0 and interpvalues[i] < minBathyDepth:
-            #interpvalues[i] = minBathyDepth
-    
-    mesh.setZ(interpvalues)
-    
-    return mesh
-#----------------------------------------------------------
-
-
-#----------------------------------------------------------
-# F U N C T I O N    C O M P U T E _ N U M C E L L S
-#----------------------------------------------------------
-#
-# Compute the total numhber of DEM cells that should be 
-# interpolated for each mesh node using the CCA method
-# of Bilskie & Hagen (2013)
-# result = function(mesh, rastersize)
-#----------------------------------------------------------
-def compute_numcells(mesh,rastersize):
-
-    # mesh -> mesh object
-    # rastersize -> floating point of DEM cell size
-
-    # Reproject the mesh to UTM coordinates
-    #mesh.reproject(26916)
-
-    sfactor = np.ones(mesh.numNodes())
-    for i in range(mesh.numNodes()):
-        
-        if (mesh.node(i).z() < -1001 ) and (mesh.node(i).z() > -1100) :
-            sfactor[i] = mesh.node(i).z()*-1 - 1000
-        
-        # values of -2000 or less are flagged as vertical/raised feature nodes
-        elif (mesh.node(i).z() == -2000):
-            sfactor[i] = 2.0
-        
+            values, num_values = gathervalues(
+                mesh,
+                raster,
+                cell_radii,
+                control_areas,
+                multiplication_factor,
+                values,
+                num_values,
+            )
         else:
-            sfactor[i] = 1.0
-    
-    # Compute N (# of DEM cells radiating omnidirectionally form the cell center)
-    N = [(0.25*x)/rastersize for x in mesh.size]
-    N = N * sfactor
-    # Compute the total number of DEM cells to average
-    N = np.asarray(N)
-    N = np.round(N)
-    CA = np.piecewise(N, [N < 1, N >= 1], [1, (2*N+1)**2])
-    return N, CA
-#----------------------------------------------------------
+            values, num_values = griddata(
+                mesh,
+                meshconn,
+                xc,
+                yc,
+                boundary_nodes,
+                raster,
+                multiplication_factor,
+                values,
+                num_values,
+            )
+
+    interpolated_values = np.zeros(mesh.numNodes())
+    for index in range(mesh.numNodes()):
+        if num_values[index] == 0:
+            interpolated_values[index] = mesh.node(index).z()
+        elif num_values[index] == -2000:
+            interpolated_values[index] = values[index]
+        else:
+            interpolated_values[index] = values[index] / num_values[index]
+
+        if 0 <= interpolated_values[index] < minimum_bathymetric_depth:
+            interpolated_values[index] = minimum_bathymetric_depth
+
+    mesh.setZ(interpolated_values)
+    return mesh
+
+
+def compute_numcells(mesh, raster_size):
+    """Compute raster-cell radii and expected control-area sizes per node."""
+    if raster_size <= 0:
+        raise ValueError("Raster size must be positive")
+
+    scale_factors = np.ones(mesh.numNodes())
+    for index in range(mesh.numNodes()):
+        elevation = mesh.node(index).z()
+        if -1100 < elevation < -1001:
+            scale_factors[index] = -elevation - 1000
+        elif elevation == -2000:
+            scale_factors[index] = 2.0
+
+    cell_radii = (0.25 * np.asarray(mesh.size)) / raster_size
+    cell_radii = np.round(cell_radii * scale_factors)
+    control_areas = np.where(cell_radii < 1, 1, (2 * cell_radii + 1) ** 2)
+    return cell_radii, control_areas

--- a/pydem2grd/src/raster.py
+++ b/pydem2grd/src/raster.py
@@ -1,116 +1,57 @@
-# File: raster.py
-# Name: Matthew V. Bilskie
+"""Raster coordinate and data helpers backed by Rasterio."""
 
-#----------------------------------------------------------
-# M O D U L E S                                   
-#----------------------------------------------------------
-import numpy as np
-from osgeo import gdal
+from pathlib import Path
+
 import rasterio
-#----------------------------------------------------------
+from rasterio.transform import rowcol, xy
 
 
-#----------------------------------------------------------
-# F U N C T I O N    G E T _ R A S T V A L U E    
-#----------------------------------------------------------
-#
-# Finds the raster value for a given row,col in a raster
-# result = function(row,col,gdal raster)
-#----------------------------------------------------------
-def get_rastvalue(col,row,rdata):
-    geoTransform = rdata.GetGeoTransform()
-    band = rdata.GetRasterBand(1)
-    vals = band.ReadAsArray()
-    return vals[col][row]
-#----------------------------------------------------------
+def open_raster(path):
+    """Open a raster path with Rasterio."""
+    return rasterio.open(Path(path))
 
-#----------------------------------------------------------
-# F U N C T I O N    G E T _ B O U N D I N G B O X
-#----------------------------------------------------------
-#
-# Finds the bounding box (xmin/ymin/xmax/ymax) for a raster
-# result = function(gdal raster)
-#----------------------------------------------------------
+
+def get_rastvalue(col, row, rdata):
+    """Return the first-band value at a zero-based column and row."""
+    return rdata.read(1)[row, col]
+
+
 def get_boundingbox(rdata):
-    geoTransform = rdata.GetGeoTransform()
-    minx = geoTransform[0]
-    maxy = geoTransform[3]
-    maxx = minx + geoTransform[1] * rdata.RasterXSize
-    miny = maxy + geoTransform[5] * rdata.RasterYSize
-    bbox = [minx, miny, maxx, maxy]
-    data = None
-    return bbox
-#----------------------------------------------------------
+    """Return raster bounds as ``[xmin, ymin, xmax, ymax]``."""
+    bounds = rdata.bounds
+    return [bounds.left, bounds.bottom, bounds.right, bounds.top]
 
-#----------------------------------------------------------
-# F U N C T I O N    G E T _ N U M R O W C O L              
-#----------------------------------------------------------
-#
-# Finds the total number of rows and columns in a raster
-# result = function(gdal raster)
-#----------------------------------------------------------
+
 def get_numrowcol(rdata):
-    geoTransform = rdata.GetGeoTransform()
-    return rdata.RasterXSize, rdata.RasterYSize
-#----------------------------------------------------------
+    """Return the raster's column and row counts."""
+    return rdata.width, rdata.height
 
-#----------------------------------------------------------
-# F U N C T I O N    I S I N R A S T E R              
-#----------------------------------------------------------
-#
-# Finds if a give mesh node is inside a raster
-# result = function(x,y,gdal raster)
-#----------------------------------------------------------
-def isinraster(x,y,rdata):
-    bbox = get_boundingbox(rdata)
-    if ( (x > bbox[0]) and (x < bbox[2]) and
-            (y > bbox[1]) and (y < bbox[3]) ):
-        # Inside the raster bbox
-        return True
-    else:
-        return False
-#----------------------------------------------------------
 
-#----------------------------------------------------------
-# F U N C T I O N    G E T _ R A S T E R S I Z E      
-#----------------------------------------------------------
-#
-# Finds if the cell size of a raster           
-# result = function(gdal raster)
-#----------------------------------------------------------
+def isinraster(x, y, rdata):
+    """Return whether a coordinate lies strictly inside the raster bounds."""
+    xmin, ymin, xmax, ymax = get_boundingbox(rdata)
+    return xmin < x < xmax and ymin < y < ymax
+
+
 def get_rastersize(rdata):
-    geoTransform = rdata.GetGeoTransform()
-    return geoTransform[1]
-#----------------------------------------------------------
+    """Return the absolute horizontal pixel resolution."""
+    return abs(float(rdata.res[0]))
 
-#----------------------------------------------------------
-# F U N C T I O N    C O O R D 2 P I X E L            
-#----------------------------------------------------------
-#
-# Finds the row and column for a given x,y pair in a raster
-# result = function(x,y,gdal raster)
-#----------------------------------------------------------
-def coord2pixel(x,y,rdata):
-    gt = rdata.GetGeoTransform()
-    if (isinraster(x,y,rdata)):
-        col = np.int((x - gt[0]) / gt[1])
-        row = np.int((gt[3] - y) / -gt[5])
-        return col,row
-    else:
-        return (-1,-1)
 
-#----------------------------------------------------------
+def coord2pixel(x, y, rdata):
+    """Convert map coordinates to a zero-based ``(column, row)`` pair."""
+    if not isinraster(x, y, rdata):
+        return -1, -1
+    row, col = rowcol(rdata.transform, x, y)
+    return int(col), int(row)
 
-#----------------------------------------------------------
-# F U N C T I O N    P I X E L 2 C O O R D            
-#----------------------------------------------------------
-#
-# Finds the row and column for a given x,y pair in a raster
-# result = function(row,col,gdal raster)
-#----------------------------------------------------------
-def pixel2coord(col,row,rdata):
-    xoff, a, b, yoff, d, e = rdata.GetGeoTransform()
-    x = a * col + b * row + xoff
-    y = d * col + e * row + yoff
-    return(x,y)
-#----------------------------------------------------------
+
+def pixel2coord(col, row, rdata):
+    """Return map coordinates for the upper-left corner of a raster cell."""
+    xcoord, ycoord = xy(rdata.transform, row, col, offset="ul")
+    return float(xcoord), float(ycoord)
+
+
+def read_band_as_array(rdata, masked=False):
+    """Read the first raster band."""
+    return rdata.read(1, masked=masked)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pydem2grd"
+version = "0.1.0"
+description = "Interpolate DEM rasters onto ADCIRC fort.14 meshes"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+  {name = "Matthew V. Bilskie"},
+]
+license = {file = "LICENSE"}
+dependencies = [
+  "numpy",
+  "rasterio",
+  "shapely",
+]
+
+[project.scripts]
+pydem2grd = "pydem2grd.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["pydem2grd*"]

--- a/rasterlist.txt
+++ b/rasterlist.txt
@@ -1,2 +1,1 @@
-./dem2grd/data/SACS_MS_AL_3mGrid_10_utm16.nc
-./dem2grd/data/SACS_MS_AL_3mGrid_11_utm16.nc
+./example/Example_DEM_GA.tif

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -1,0 +1,143 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    from pydem2grd.mesh import Mesh
+    from pydem2grd.src.interpolate import interpolate
+    from pydem2grd.src.raster import (
+        coord2pixel,
+        get_boundingbox,
+        get_numrowcol,
+        get_rastersize,
+        pixel2coord,
+    )
+except ImportError:
+    np = None
+
+
+@unittest.skipIf(np is None, "scientific dependencies are not installed")
+class InterpolationTest(unittest.TestCase):
+    def _raster(self, directory, values, nodata=-9999.0):
+        path = Path(directory) / "dem.tif"
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=values.shape[0],
+            width=values.shape[1],
+            count=1,
+            dtype=values.dtype,
+            transform=from_origin(0.0, 3.0, 1.0, 1.0),
+            nodata=nodata,
+        ) as dataset:
+            dataset.write(values, 1)
+        return path
+
+    def _mesh(self, directory, elevation=-1001.0):
+        path = Path(directory) / "mesh.14"
+        path.write_text(
+            "single node\n"
+            "0 1\n"
+            "10 1.5 1.5 {}\n".format(elevation)
+            + "0 = Number of open boundaries\n"
+            + "0 = Total number of open boundary nodes\n"
+            + "0 = Number of land boundaries\n"
+            + "0 = Total number of land boundary nodes\n",
+            encoding="utf-8",
+        )
+        return Mesh.from_file(path)
+
+    def _square_mesh(self, directory):
+        path = Path(directory) / "square.14"
+        path.write_text(
+            "square mesh\n"
+            "2 4\n"
+            "10 0.5 0.5 -1001\n"
+            "20 2.5 0.5 -1001\n"
+            "30 2.5 2.5 -1001\n"
+            "40 0.5 2.5 -1001\n"
+            "7 3 10 20 30\n"
+            "11 3 10 30 40\n"
+            "0 = Number of open boundaries\n"
+            "0 = Total number of open boundary nodes\n"
+            "0 = Number of land boundaries\n"
+            "0 = Total number of land boundary nodes\n",
+            encoding="utf-8",
+        )
+        return Mesh.from_file(path)
+
+    def test_raster_coordinate_helpers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            raster_path = self._raster(
+                directory, np.arange(1, 10, dtype="float32").reshape(3, 3)
+            )
+            with rasterio.open(raster_path) as dataset:
+                self.assertEqual(get_boundingbox(dataset), [0.0, 0.0, 3.0, 3.0])
+                self.assertEqual(get_numrowcol(dataset), (3, 3))
+                self.assertEqual(get_rastersize(dataset), 1.0)
+                self.assertEqual(coord2pixel(1.5, 1.5, dataset), (1, 1))
+                self.assertEqual(pixel2coord(1, 1, dataset), (1.0, 2.0))
+
+    def test_ca_interpolation_reads_center_cell_for_zero_radius(self):
+        with tempfile.TemporaryDirectory() as directory:
+            raster_path = self._raster(
+                directory, np.arange(1, 10, dtype="float32").reshape(3, 3)
+            )
+            raster_list = Path(directory) / "rasters.txt"
+            raster_list.write_text(str(raster_path) + "\n", encoding="utf-8")
+
+            mesh = interpolate(self._mesh(directory), raster_list, 0.0, 1.0, "CA")
+            self.assertEqual(mesh.node(0).z(), 5.0)
+
+    def test_ca_interpolation_ignores_nodata(self):
+        with tempfile.TemporaryDirectory() as directory:
+            values = np.arange(1, 10, dtype="float32").reshape(3, 3)
+            values[1, 1] = -9999.0
+            raster_path = self._raster(directory, values)
+            raster_list = Path(directory) / "rasters.txt"
+            raster_list.write_text(str(raster_path) + "\n", encoding="utf-8")
+
+            mesh = interpolate(self._mesh(directory), raster_list, 0.0, 1.0, "CA")
+            self.assertEqual(mesh.node(0).z(), -1001.0)
+
+    def test_griddata_supports_non_contiguous_element_ids(self):
+        with tempfile.TemporaryDirectory() as directory:
+            raster_path = self._raster(
+                directory, np.arange(1, 10, dtype="float32").reshape(3, 3)
+            )
+            raster_list = Path(directory) / "rasters.txt"
+            raster_list.write_text(str(raster_path) + "\n", encoding="utf-8")
+
+            mesh = interpolate(
+                self._square_mesh(directory), raster_list, 0.0, 1.0, "griddata"
+            )
+            self.assertTrue(
+                any(mesh.node(index).z() != -1001.0 for index in range(mesh.numNodes()))
+            )
+
+    def test_checked_in_example_ca_smoke(self):
+        repository = Path(__file__).parents[1]
+        mesh = Mesh.from_file(repository / "example" / "mesh_x1002.grd")
+        original = [mesh.node(index).z() for index in range(mesh.numNodes())]
+
+        with tempfile.TemporaryDirectory() as directory:
+            raster_list = Path(directory) / "rasters.txt"
+            raster_list.write_text(
+                str(repository / "example" / "Example_DEM_GA.tif") + "\n",
+                encoding="utf-8",
+            )
+            interpolate(mesh, raster_list, 0.0, -1.0, "CA")
+
+        changed = sum(
+            mesh.node(index).z() != original[index] for index in range(mesh.numNodes())
+        )
+        self.assertGreater(changed, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,77 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from pydem2grd.mesh import Fort14Error, Mesh
+
+
+FORT14 = """two triangle mesh
+2 4
+10 0.0 0.0 -1002.0
+20 1.0 0.0 -1002.0
+30 1.0 1.0 2.5
+40 0.0 1.0 -2000.0
+7 3 10 20 30
+11 3 10 30 40
+1 = Number of open boundaries
+2 = Total number of open boundary nodes
+2 0 = boundary 1
+10
+20
+0 = Number of land boundaries
+0 = Total number of land boundary nodes
+"""
+
+
+class MeshTest(unittest.TestCase):
+    def _write(self, directory, name="fort.14", contents=FORT14):
+        path = Path(directory) / name
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_reads_non_contiguous_ids_and_builds_topology(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mesh = Mesh.from_file(self._write(directory))
+
+        self.assertEqual(mesh.title, "two triangle mesh")
+        self.assertEqual(mesh.numNodes(), 4)
+        self.assertEqual(mesh.numElements(), 2)
+        self.assertEqual(mesh.nodeIndexById(30), 2)
+        self.assertEqual(mesh.elementIndexById(11), 1)
+        self.assertEqual(mesh.connectivity(), [[10, 20, 30], [10, 30, 40]])
+        self.assertEqual(mesh.numElementsAroundNode(mesh.nodeIndexById(10)), 2)
+        self.assertEqual({node.id() for node in mesh.boundaryNodes()}, {10, 20, 30, 40})
+        for actual, expected in zip(
+            mesh.computeMeshSize(), [1.13807119, 1.0, 1.13807119, 1.0]
+        ):
+            self.assertAlmostEqual(actual, expected)
+
+    def test_round_trip_retains_boundary_section_and_updates_elevations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._write(directory)
+            output = Path(directory) / "output.14"
+            mesh = Mesh.from_file(source)
+            mesh.setZ([1.0, 2.0, 3.0, 4.0])
+            mesh.write(output)
+            result = Mesh.from_file(output)
+
+            self.assertEqual([result.node(i).z() for i in range(4)], [1.0, 2.0, 3.0, 4.0])
+            self.assertIn("2 0 = boundary 1", output.read_text(encoding="utf-8"))
+
+    def test_rejects_unknown_element_node(self):
+        invalid = FORT14.replace("7 3 10 20 30", "7 3 10 20 99")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(Fort14Error, "unknown node ID"):
+                Mesh.from_file(self._write(directory, contents=invalid))
+
+    def test_checked_in_example_is_a_valid_mesh(self):
+        example = Path(__file__).parents[1] / "example" / "mesh_x1002.grd"
+        mesh = Mesh.from_file(example)
+        self.assertEqual(mesh.numNodes(), 4596)
+        self.assertEqual(mesh.numElements(), 8941)
+        self.assertEqual(mesh.node(mesh.nodeIndexById(4599)).id(), 4599)
+        self.assertEqual(mesh.elementIndexById(8956), 8940)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add native ADCIRC `fort.14` mesh reading and writing
- preserve boundary records and support non-contiguous node and element IDs
- remove the ADCIRC Modules and direct `osgeo.gdal` dependencies
- use Rasterio for DEM access while retaining the CA and `griddata` interpolation methods
- add installable Python packaging, a Conda environment, CLI documentation, and regression coverage

## Validation

- 9 unit and integration tests pass
- the checked-in 4,596-node, 8,941-element example completes a full CLI interpolation and output round trip
- both CA and `griddata` paths are covered
- the project builds successfully as a Python wheel
